### PR TITLE
Enable tf.Tensor inputs in coupled_logarithm

### DIFF
--- a/nsc/math/function.py
+++ b/nsc/math/function.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 import numpy as np
+import tensorflow as tf
 import warnings
 from typing import List
 
 numeric_tuple = (int, float, np.float32, np.float64, np.longdouble)
 
 
-def coupled_logarithm(value: [int, float, np.ndarray],
+def coupled_logarithm(value: [int, float, np.ndarray, tf.Tensor],
                       kappa: [int, float] = 0.0,
                       dim: int = 1
-                      ) -> [float, np.ndarray]:
+                      ) -> [float, np.ndarray, tf.Tensor]:
     """
     Generalization of the logarithm function, which defines smooth
     transition to power functions.
@@ -17,7 +18,7 @@ def coupled_logarithm(value: [int, float, np.ndarray],
     Parameters
     ----------
     value : Input variable in which the coupled logarithm is applied to.
-            Accepts int, float, and np.ndarray data types.
+            Accepts int, float, np.ndarray and tf.Tensor data types.
     kappa : Coupling parameter which modifies the coupled logarithm function.
             Accepts int and float data types.
     dim : The dimension (or rank) of value. If value is scalar, then dim = 1.
@@ -25,8 +26,8 @@ def coupled_logarithm(value: [int, float, np.ndarray],
     """
     # convert value into np.ndarray (if scalar) to keep consistency
     value = np.array(value) if isinstance(value, numeric_tuple) else value
-    assert isinstance(value, np.ndarray), "value must be an int, float, or np.ndarray."
-    assert 0. not in value, "value must not be or contain np.ndarray zero(s)."
+    assert isinstance(value, np.ndarray, tf.Tensor), "value must be an int, float, np.ndarray or tf.Tensor."
+    assert 0. not in value, "value must not be or contain zero(s)."
     if kappa == 0.:
         coupled_log_value = np.log(value)  # divide by 0 if x == 0
     else:


### PR DESCRIPTION
Needed so that coupled_cross_entropy_prob can accept tf.Tensors.